### PR TITLE
[v1.5.8] fix: prevent crash onhover of smithing recipe without metal or material variant

### DIFF
--- a/SmithingPlus/ClientTweaks/RecipeVoxelCountPatch.cs
+++ b/SmithingPlus/ClientTweaks/RecipeVoxelCountPatch.cs
@@ -101,6 +101,7 @@ public static class RecipeVoxelCountPatch
             var voxelCount = CacheHelper.GetOrAdd(Core.RecipeVoxelCountCache, recipeId,
                 () =>  capi.GetSmithingRecipes().Find(recipe => recipe.RecipeId == recipeId).Voxels.VoxelCount());
             var baseMaterial = selectedRecipe.Output.ResolvedItemstack.GetMetalMaterialStack(capi);
+            if (baseMaterial == null) return;
             var bitsCount = (int) Math.Ceiling(voxelCount / Core.Config.VoxelsPerBit);
             var countDesc = Lang.Get("Requires any of: ");
             var currentSkillItem = skillItems[num];

--- a/SmithingPlus/Util/CollectibleExtensions.cs
+++ b/SmithingPlus/Util/CollectibleExtensions.cs
@@ -37,7 +37,13 @@ public static class CollectibleExtensions
     public static ItemStack GetMetalMaterialStack(this CollectibleObject collObj, ICoreAPI api = null)
     {
         api ??= Core.Api;
-        var ingotItem = api?.World.GetItem(new AssetLocation("game:ingot-" + collObj.GetMetalOrMaterial()));
+        var metalOrMaterial = collObj.GetMetalOrMaterial();
+        if (metalOrMaterial == null)
+        {
+            api.Logger.Warning("Collectible {0} has no metal or material variant set", collObj.Code);
+            return null;
+        }
+        var ingotItem = api?.World.GetItem(new AssetLocation("game:ingot-" + metalOrMaterial));
         return new ItemStack(ingotItem);
     }
 

--- a/SmithingPlus/modinfo.json
+++ b/SmithingPlus/modinfo.json
@@ -4,6 +4,6 @@
   "name": "SmithingPlus",
   "authors": [ "jayu" ],
   "description": "Add bits when smithing and other tweaks",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "dependencies": { "game": "" }
 }


### PR DESCRIPTION
Not intending to merge to master, but this is my local fix of https://github.com/jayugg/SmithingPlus/issues/41 based on v1.5.7.