### PR TITLE
[Compatibility] Extract bit recovery into standalone method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ riderModule.iml
 /.idea/**/*
 /Releases/**/*
 *.sln.DotSettings.user
+/.vs/SmithingPlus
+/.vs/ProjectEvaluation

--- a/SmithingPlus/BitsRecovery/BitsRecoveryPatches.cs
+++ b/SmithingPlus/BitsRecovery/BitsRecoveryPatches.cs
@@ -41,7 +41,11 @@ public class BitsRecoveryPatches
             Core.Logger.VerboseDebug("[BitsRecovery] Non-metal voxel type: {0}", voxelType);
             return;
         }
+        RecoverBitsFromWorkItem(__instance, byPlayer, workItemStack);
+    }
 
+    private static void RecoverBitsFromWorkItem(BlockEntityAnvil __instance, IPlayer byPlayer, ItemStack workItemStack)
+    {
         var splitCount = __instance.WorkItemStack.GetSplitCount();
         var bitsPerVoxel = 1f / Core.Config.VoxelsPerBit;
         splitCount += bitsPerVoxel;
@@ -56,8 +60,7 @@ public class BitsRecoveryPatches
         var metalMaterial = workItemStack.GetMetalMaterialProcessed(byPlayer.Entity.Api);
         if (!(metalMaterial?.Resolved ?? false))
         {
-            Core.Logger.VerboseDebug(
-                "[BitsRecovery#BEAnvil_OnUseOver_Postfix] No valid metal material found in work item.");
+            Core.Logger.VerboseDebug("[BitsRecovery#BEAnvil_OnUseOver_Postfix] No valid metal material found in work item.");
             return;
         }
 


### PR DESCRIPTION
Fixes: #63 

Hi, I'd like to arrange a slight tweak to your bit recovery patch, so that I can hook into the method within Knapster to allow for compatibility between the two mods. With this small change, I can execute the method to be able to recover bits, while using the auto-complete mode in Knapster, as per the feature request, [here](https://github.com/ApacheTech-VintageStory-Mods/Knapster/issues/40). I use a similar technique to add compatibility with Anvil Metal Recovery.

This is the code I would need to add to Knapster to make the compatibility work. Previous attempts have lead to needing to re-write large parts of your mod, which makes it unmaintainable in the long-run.

```csharp
    private static void SmithingPlusBitRecovery(BlockEntityAnvil __instance, IPlayer byPlayer)
    {
        if (!ApiEx.Current.ModLoader.AreAnyModsLoaded("smithingplus")) return;
        if (__instance.WorkItemStack is not { } workItemStack) return;
        var type = AccessTools.TypeByName("SmithingPlus.BitsRecovery.BitsRecoveryPatches");
        var method = AccessTools.Method(type, "RecoverBitsFromWorkItem");
        method?.Invoke(null, [__instance, byPlayer, workItemStack]);
    }
```