### PR TITLE
Adjusted casting metal requirements patch

### DIFF
--- a/SmithingPlus/AdjustedCastingMetalRequirements/CastingMetalRequirementsPatch.cs
+++ b/SmithingPlus/AdjustedCastingMetalRequirements/CastingMetalRequirementsPatch.cs
@@ -3,10 +3,10 @@ using HarmonyLib;
 using JetBrains.Annotations;
 using Vintagestory.GameContent;
 
-namespace SmithingPlus.CastingTweaks;
+namespace SmithingPlus.AdjustedCastingMetalRequirements;
 
 [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
-[HarmonyPatchCategory(Core.CastingTweaksCategory)]
+[HarmonyPatchCategory(Core.AdjustedCastingMetalRequirementsCategory)]
 public static class CastingMetalRequirementsPatch
 {
     private static readonly Dictionary<string, int> AdjustedRequiredUnits = new()

--- a/SmithingPlus/CastingTweaks/CastingMetalRequirementsPatch.cs
+++ b/SmithingPlus/CastingTweaks/CastingMetalRequirementsPatch.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using HarmonyLib;
+using JetBrains.Annotations;
+using Vintagestory.GameContent;
+
+namespace SmithingPlus.CastingTweaks;
+
+[UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
+[HarmonyPatchCategory(Core.CastingTweaksCategory)]
+public static class CastingMetalRequirementsPatch
+{
+    private static readonly Dictionary<string, int> AdjustedRequiredUnits = new()
+    {
+        { "axe", 90 },
+        { "pickaxe", 60 },
+        { "shovel", 90 },
+        { "hammer", 100 },
+        { "hoe", 85 },
+        { "prospectingpick", 40 },
+        { "helvehammer", 190 },
+        { "blade-falx", 100 }
+    };
+
+    [HarmonyPostfix]
+    [HarmonyPatch(typeof(BlockEntityToolMold), nameof(BlockEntityToolMold.Initialize))]
+    public static void Postfix_Initialize(BlockEntityToolMold __instance)
+    {
+        string itemType = __instance.Block?.Variant?["tooltype"];
+        if (itemType != null && AdjustedRequiredUnits.TryGetValue(itemType, out int adjustedUnits))
+        {
+            var requiredUnitsfield = AccessTools.Field(typeof(BlockEntityToolMold), "requiredUnits");
+            requiredUnitsfield?.SetValue(__instance, adjustedUnits);
+        }
+    }
+}

--- a/SmithingPlus/Config/ServerConfig.cs
+++ b/SmithingPlus/Config/ServerConfig.cs
@@ -32,6 +32,7 @@ public class ServerConfig
     public string ArrowSelector { get; set; } = "@(.*):arrow-(.*)";
     public bool MetalCastingTweaks { get; set; } = true;
     public float CastToolDurabilityPenalty { get; set; } = 0.1f;
+    public bool AdjustedCastingMetalRequirements { get; set; } = true;
     public bool HammerTweaks { get; set; } = true;
     public bool RotationRequiresTongs { get; set; } = false;
     public bool AnvilShowRecipeVoxels { get; set; } = true;

--- a/SmithingPlus/Core.PatchCategories.cs
+++ b/SmithingPlus/Core.PatchCategories.cs
@@ -10,6 +10,7 @@ public partial class Core
     internal const string BitsRecoveryCategory = "bitsRecovery";
     internal const string HelveHammerBitsRecoveryCategory = $"{BitsRecoveryCategory}.helveHammer";
     internal const string CastingTweaksCategory = "castingTweaks";
+    internal const string AdjustedCastingMetalRequirementsCategory = "adjustedCastingMetalRequirements";
     internal const string HammerTweaksCategory = "hammerTweaks";
 
     internal static class ClientTweaksCategories

--- a/SmithingPlus/Core.cs
+++ b/SmithingPlus/Core.cs
@@ -132,6 +132,7 @@ public partial class Core : ModSystem
         BitsRecoveryCategory.PatchIfEnabled(Config.RecoverBitsOnSplit);
         HelveHammerBitsRecoveryCategory.PatchIfEnabled(Config.HelveHammerBitsRecovery);
         CastingTweaksCategory.PatchIfEnabled(Config.MetalCastingTweaks);
+        AdjustedCastingMetalRequirementsCategory.PatchIfEnabled(Config.AdjustedCastingMetalRequirements);
         SmithingBitsCategory.PatchIfEnabled(Config.SmithWithBits || Config.BitsTopUp);
         HammerTweaksCategory.PatchIfEnabled(Config.HammerTweaks);
         //StoneSmithingCategory.PatchIfEnabled(true);

--- a/SmithingPlus/assets/smithingplus/config/configlib-patches.json
+++ b/SmithingPlus/assets/smithingplus/config/configlib-patches.json
@@ -202,6 +202,14 @@
       "range": { "min": 0, "max": 1 }
     },
     {
+      "code": "AdjustedCastingMetalRequirements",
+      "ingui": "smithingplus:setting-adjustedcastingmetalrequirements",
+      "type": "boolean",
+      "weight": 0.77,
+      "comment": "Align metal requirement of cast items with smithed ones",
+      "default": true
+    },
+    {
       "code": "HammerTweaks",
       "ingui": "smithingplus:setting-hammertweaks",
       "type": "boolean",

--- a/SmithingPlus/assets/smithingplus/lang/en.json
+++ b/SmithingPlus/assets/smithingplus/lang/en.json
@@ -24,6 +24,7 @@
   "setting-arrowselector": "Arrow selector",
   "setting-metalcastingtweaks": "Metal casting tweaks",
   "setting-casttooldurabilitypenalty": "Cast tool durability penalty",
+  "setting-adjustedcastingmetalrequirements": "Casting metal requirement adjustment",
   "setting-hammertweaks": "Hammer tweaks",
   "setting-rotationrequirestongs": "Rotation requires tongs",
   "setting-anvilshowrecipevoxels": "Show recipe voxel count",

--- a/SmithingPlus/assets/smithingplus/lang/it.json
+++ b/SmithingPlus/assets/smithingplus/lang/it.json
@@ -24,6 +24,7 @@
   "setting-arrowselector": "Selettore per frecce",
   "setting-metalcastingtweaks": "Modifiche alla stampatura dei metalli",
   "setting-casttooldurabilitypenalty": "Penalità alla durabilità per attrezzi stampati",
+  "setting-adjustedcastingmetalrequirements": "Regolazione del requisito di metallo da colata",
   "setting-hammertweaks": "Modifiche al martello",
   "setting-rotationrequirestongs": "La rotazione richiede pinze",
   "setting-anvilshowrecipevoxels": "Mostra conteggio voxel della ricetta",

--- a/SmithingPlus/assets/smithingplus/lang/pl.json
+++ b/SmithingPlus/assets/smithingplus/lang/pl.json
@@ -24,6 +24,7 @@
   "setting-arrowselector": "Selektor strzał",
   "setting-metalcastingtweaks": "Ulepszenia odlewania metali",
   "setting-casttooldurabilitypenalty": "Kara trwałości dla odlewanego narzędzia",
+  "setting-adjustedcastingmetalrequirements": "Dostosowanie wymagań metalu do odlewania",
   "setting-hammertweaks": "Ulepszenia młotów",
   "setting-rotationrequirestongs": "Obrót wymaga szczypiec",
   "setting-anvilshowrecipevoxels": "Pokaż liczbę wokseli w przepisie",

--- a/SmithingPlus/assets/smithingplus/lang/ru.json
+++ b/SmithingPlus/assets/smithingplus/lang/ru.json
@@ -24,6 +24,7 @@
   "setting-arrowselector": "Выбор стрел",
   "setting-metalcastingtweaks": "Настройки литья металла",
   "setting-casttooldurabilitypenalty": "Снижение прочности литых инструментов",
+  "setting-adjustedcastingmetalrequirements": "Корректировка требований к металлу для литья",
   "setting-hammertweaks": "Настройки молота",
   "setting-rotationrequirestongs": "Требуются щипцы для вращения",
   "setting-anvilshowrecipevoxels": "Показать количество вокселей в рецепте",

--- a/SmithingPlus/assets/smithingplus/lang/zh-cn.json
+++ b/SmithingPlus/assets/smithingplus/lang/zh-cn.json
@@ -24,6 +24,7 @@
   "setting-arrowselector": "箭矢选择器",
   "setting-metalcastingtweaks": "金属铸造调整",
   "setting-casttooldurabilitypenalty": "铸造工具耐久度惩罚",
+  "setting-adjustedcastingmetalrequirements": "铸造金属需求调整",
   "setting-hammertweaks": "锤子调整",
   "setting-rotationrequirestongs": "旋转需要钳子",
   "setting-anvilshowrecipevoxels": "显示配方体积",

--- a/SmithingPlus/changelog.txt
+++ b/SmithingPlus/changelog.txt
@@ -6,3 +6,6 @@
 
 v1.7.4
 - [Fix] Wrong output count on some bits recycling recipes because code would try to recycle the chisel instead
+
+v1.8.0
+- Add option to adjust metal unit requirements for casting to be aligned with smithing metal requirements

--- a/SmithingPlus/modinfo.json
+++ b/SmithingPlus/modinfo.json
@@ -4,6 +4,6 @@
   "name": "SmithingPlus",
   "authors": [ "jayu" ],
   "description": "Metal tool repair, smithing tweaks and QOL improvements.",
-  "version": "1.7.4",
+  "version": "1.8.0",
   "dependencies": { "game": "" }
 }


### PR DESCRIPTION
Patch to align the metal unit requirements when casting with the metal unit requirements when smithing, as brought up on the mod page.
The adjustment can be turned on/off with a boolean flag (defaults to true).

I hard-coded the values based on the smithing requirements. There might be a way to set them dynamically.

I couldn't fix the requirements that show up in the handbook extra info (number of bits) - it cycles between 20 bits and the actual amount (e.g. 12 bits for pickaxe head).