### PR TITLE
Fixed some configs not being synced to clients from server

### DIFF
--- a/SmithingPlus/Config/ConfigLoader.cs
+++ b/SmithingPlus/Config/ConfigLoader.cs
@@ -1,6 +1,8 @@
 using System;
 using JetBrains.Annotations;
+using Vintagestory.API.Client;
 using Vintagestory.API.Common;
+using Vintagestory.API.Server;
 
 namespace SmithingPlus.Config;
 
@@ -15,7 +17,22 @@ public class ConfigLoader : ModSystem
         return 0.03;
     }
 
+    public override void StartServerSide(ICoreServerAPI api)
+    {
+        SendConfigToClient(api);
+    }
+    
+    public override void StartClientSide(ICoreClientAPI api)
+    {
+        ReadConfigFromServer(api);
+    }
+
     public override void StartPre(ICoreAPI api)
+    {
+        LoadServerConfig(api);
+    }
+
+    private void LoadServerConfig(ICoreAPI api)
     {
         try
         {
@@ -26,6 +43,9 @@ public class ConfigLoader : ModSystem
                 Mod.Logger.VerboseDebug("Config file not found, creating a new one...");
             }
 
+            // Clamp and warn about issues in config.
+            VerifyConfig();
+
             api.StoreModConfig(Config, ConfigName);
         }
         catch (Exception e)
@@ -35,19 +55,33 @@ public class ConfigLoader : ModSystem
         }
     }
 
-    public override void Start(ICoreAPI api)
+    public void SendConfigToClient(ICoreAPI api)
     {
         api.World.Config.SetBool("SmithingPlus_CanRepairForlornHopeEstoc", Config.CanRepairForlornHopeEstoc);
         api.World.Config.SetBool("SmithingPlus_WorkableBits", Config.SmithWithBits || Config.EnableToolRecovery);
+        
+        api.World.Config.SetBool("SmithingPlus_DynamicMoldUnits", Config.DynamicMoldUnits);
+        api.World.Config.SetFloat("SmithingPlus_CastToolDurabilityPenalty", Config.CastToolDurabilityPenalty);
+        api.World.Config.SetFloat("SmithingPlus_DurabilityPenaltyPerRepair", Config.DurabilityPenaltyPerRepair);
+    }
+    
+    public void ReadConfigFromServer(ICoreAPI api)
+    {
+        Config.DynamicMoldUnits = api.World.Config.GetBool("SmithingPlus_DynamicMoldUnits");
+        Config.CastToolDurabilityPenalty = api.World.Config.GetFloat("SmithingPlus_CastToolDurabilityPenalty");
+        Config.DurabilityPenaltyPerRepair = api.World.Config.GetFloat("SmithingPlus_DurabilityPenaltyPerRepair");
+    }
+
+    private void VerifyConfig()
+    {
         if (Config.BrokenToolVoxelPercent < 0.2)
             Mod.Logger.Warning($"[{nameof(ConfigLoader)}] Config setting {nameof(Config.BrokenToolVoxelPercent)}" +
                                $"has a very low value, your broken tools well be almost or fully empty.");
-        ;
+
         if (Config.VoxelsPerBit is < 2 or > 3)
         {
             Mod.Logger.Warning($"[{nameof(ConfigLoader)}] Config setting {nameof(Config.VoxelsPerBit)}" +
                                $"requires a value between 2 and 3. Clamping value.");
-            ;
             Config.VoxelsPerBit = Math.Clamp(Config.VoxelsPerBit, 2, 3);
         }
     }


### PR DESCRIPTION
Send `DynamicMoldUnits`, `CastToolDurabilityPenalty`, and `DurabilityPenaltyPerRepair` to clients from the server so that tooltips and descriptions work as intended when the config has been modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured configuration lifecycle management for improved server-client synchronization.
  * Added configuration validation to detect and warn about potential misconfigurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->