### PR TITLE
Updated to support 1.22.0-rc.6

### DIFF
--- a/CakeBuild/CakeBuild.csproj
+++ b/CakeBuild/CakeBuild.csproj
@@ -1,19 +1,19 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Cake.Frosting" Version="5.0.0"/>
+        <PackageReference Include="Cake.Frosting" Version="6.1.0"/>
         <PackageReference Include="Cake.Json" Version="7.0.1"/>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.4"/>
     </ItemGroup>
 
     <ItemGroup>
-        <Reference Include="VintagestoryAPI">
-            <HintPath>$(VINTAGE_STORY)/VintagestoryAPI.dll</HintPath>
-        </Reference>
+      <Reference Include="VintagestoryAPI">
+        <HintPath>$(VINTAGE_STORY)/VintagestoryAPI.dll</HintPath>
+      </Reference>
     </ItemGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <!-- Set your vs installation here! -->
   <PropertyGroup>
-    <VINTAGE_STORY>$(VINTAGE_STORY_1_21)</VINTAGE_STORY>
+    <VINTAGE_STORY>$(VINTAGE_STORY_1_22)</VINTAGE_STORY>
     <WorldName>[TEST] SmithingPlus</WorldName>
     <TestDir>$(SolutionDir)/test</TestDir>
     <TestDataPath>$(TestDir)/VintagestoryData</TestDataPath>

--- a/SmithingPlus/CastingTweaks/CastToolPenaltyPatch.cs
+++ b/SmithingPlus/CastingTweaks/CastToolPenaltyPatch.cs
@@ -32,13 +32,13 @@ public class CastToolPenaltyPatch
     [HarmonyPatch(typeof(CollectibleObject), nameof(CollectibleObject.OnCreatedByCrafting))]
     [HarmonyPriority(Priority.Last)]
     public static void Postfix_OnCreatedByCrafting(
-        ItemSlot[] allInputslots,
+        ItemSlot[] allInputSlots,
         ItemSlot outputSlot,
         GridRecipe byRecipe)
     {
         if (outputSlot.Itemstack == null)
             return;
-        var castToolsHeads = allInputslots
+        var castToolsHeads = allInputSlots
             .Where(slot => !slot.Empty)
             .Select(slot => slot.Itemstack)
             .Where(stack =>

--- a/SmithingPlus/ClientTweaks/ShowWorkablePatches.cs
+++ b/SmithingPlus/ClientTweaks/ShowWorkablePatches.cs
@@ -34,13 +34,13 @@ public class ShowWorkablePatches
     public static void Postfix_BlockEntityForge_GetBlockInfo(BlockEntityForge __instance, IPlayer forPlayer,
         StringBuilder dsc)
     {
-        if (__instance.Contents == null) return;
+        if (__instance.WorkItemStack == null) return;
         var temperature =
-            (int)__instance.Contents.Collectible.GetTemperature(__instance.Api.World, __instance.Contents);
-        var workableTemp = __instance.Contents.GetWorkableTemperature();
+            (int)__instance.WorkItemStack.Collectible.GetTemperature(__instance.Api.World, __instance.WorkItemStack);
+        var workableTemp = __instance.WorkItemStack.GetWorkableTemperature();
         if (!(temperature > workableTemp)) return;
-        var localizedString = Lang.Get("forge-contentsandtemp", __instance.Contents.StackSize,
-            __instance.Contents.GetName(), temperature);
+        var localizedString = Lang.Get("forge-contentsandtemp", __instance.WorkItemStack.StackSize,
+            __instance.WorkItemStack.GetName(), temperature);
         const string pattern = @"(\d+(.*)°C)";
         var replacement = Regex.Replace(localizedString, pattern,
             $"<font color=\"{Constants.AnvilWorkableColor}\">$1</font>");

--- a/SmithingPlus/Common/CollectibleBehaviorRecycledBit.cs
+++ b/SmithingPlus/Common/CollectibleBehaviorRecycledBit.cs
@@ -12,25 +12,28 @@ public class CollectibleBehaviorRecycledBit(CollectibleObject collObj) : Collect
     private ICoreAPI Api => collObj.GetField<ICoreAPI>("api");
 
     public override void OnCreatedByCrafting(
-        ItemSlot[] allInputslots,
+        ItemSlot[] allInputSlots,
         ItemSlot outputSlot,
-        GridRecipe byRecipe,
+        IRecipeBase byRecipe,
         ref EnumHandling bhHandling)
     {
-        base.OnCreatedByCrafting(allInputslots, outputSlot, byRecipe, ref bhHandling);
+        base.OnCreatedByCrafting(allInputSlots, outputSlot, byRecipe, ref bhHandling);
         if (outputSlot?.Itemstack == null ||
-            allInputslots == null ||
-            byRecipe?.resolvedIngredients == null)
+            allInputSlots == null ||
+            byRecipe == null)
             return;
 
+        var gridRecipe = byRecipe as GridRecipe;
+        var resolvedIngredients = gridRecipe?.ResolvedIngredients;
+
         // Identify recipe tools from ingredients
-        var toolIngredients = byRecipe.resolvedIngredients
+        var toolIngredients = resolvedIngredients
             .Where(ing =>
                 ing is { IsTool: true } ||
                 ing?.RecipeAttributes?[ModRecipeAttributes.RecyclingRecipe]?.AsBool() == true)
             .ToArray() ?? [];
 
-        var metalInputSlots = allInputslots
+        var metalInputSlots = allInputSlots
             .Where(s => s?.Itemstack != null)
             .Where(s => !IsToolStack(s.Itemstack, toolIngredients))
             .Where(s => s.Itemstack?.GetOrCacheMetalMaterial(Api)?.IngotStack != null)
@@ -61,17 +64,17 @@ public class CollectibleBehaviorRecycledBit(CollectibleObject collObj) : Collect
                 var cheapestRecipe = stack.GetCheapestSmithingRecipe(Api);
                 if (cheapestRecipe != null)
                 {
-                    var cheapestOutput = Math.Max(cheapestRecipe.Output.ResolvedItemstack.StackSize, 1);
+                    var cheapestOutput = Math.Max(cheapestRecipe.Output.ResolvedItemStack.StackSize, 1);
                     var recipeMaterialVoxels = cheapestRecipe.Voxels.VoxelCount();
                     var voxelsPerItem = Math.Max(recipeMaterialVoxels / cheapestOutput, 0);
 
                     var consumedStackSize =
                         0; // Use this NOT stack.StackSize because that could have more items than the recipe requires
-                    foreach (var ingredient in byRecipe.resolvedIngredients)
+                    foreach (var ingredient in resolvedIngredients)
                     {
                         if (!ingredient.SatisfiesAsIngredient(stack))
                             continue;
-                        consumedStackSize = ingredient.ResolvedItemstack.StackSize;
+                        consumedStackSize = ingredient.ResolvedItemStack.StackSize;
                         break;
                     }
 
@@ -94,7 +97,7 @@ public class CollectibleBehaviorRecycledBit(CollectibleObject collObj) : Collect
         outputSlot.Itemstack.Collectible.SetTemperature(Api.World, outputSlot.Itemstack, temperature);
     }
 
-    private static bool IsToolStack(ItemStack stack, GridRecipeIngredient[] toolIngredients)
+    private static bool IsToolStack(ItemStack stack, CraftingRecipeIngredient[] toolIngredients)
     {
         return stack != null && toolIngredients.Any(ing => ing?.SatisfiesAsIngredient(stack) == true);
     }

--- a/SmithingPlus/Common/Metal/MetalMaterialExtensions.cs
+++ b/SmithingPlus/Common/Metal/MetalMaterialExtensions.cs
@@ -27,7 +27,7 @@ public static class MetalMaterialExtensions
 
         // If that fails (coke oven door), try to get the variant from the smithing recipe
         var smithingRecipe = collObj.GetSmithingRecipe(api);
-        if (smithingRecipe is { Ingredient.ResolvedItemstack: var ingredientStack })
+        if (smithingRecipe is { Ingredient.ResolvedItemStack: var ingredientStack })
         {
             var metalVariant = ingredientStack.Collectible.GetMetalVariant();
             metalMaterial = MetalMaterialLoader.GetMaterial(api, metalVariant);
@@ -77,11 +77,11 @@ public static class MetalMaterialExtensions
         foreach (var gridRecipe in gridRecipes)
         {
             var ingredients =
-                from ing in gridRecipe.resolvedIngredients
-                where ing is { ResolvedItemstack: not null } &&
+                from ing in gridRecipe.ResolvedIngredients
+                where ing is { ResolvedItemStack: not null } &&
                       !ing.IsTool &&
-                      ing.ResolvedItemstack.Collectible != null
-                select ing.ResolvedItemstack.Collectible;
+                      ing.ResolvedItemStack.Collectible != null
+                select ing.ResolvedItemStack.Collectible;
             foreach (var ingredient in ingredients)
             {
                 if (ingredient == null) continue;
@@ -102,7 +102,7 @@ public static class MetalMaterialExtensions
 
     public static MetalMaterial? GetMetalMaterialSmelted(this CollectibleObject collectibleObject, ICoreAPI api)
     {
-        var variantCode = collectibleObject?.CombustibleProps?.SmeltedStack?.ResolvedItemstack.Collectible
+        var variantCode = collectibleObject?.CombustibleProps?.SmeltedStack?.ResolvedItemStack.Collectible
             .GetMetalVariant();
         return variantCode == null ? null : MetalMaterialLoader.GetMaterial(api, variantCode);
     }
@@ -115,7 +115,7 @@ public static class MetalMaterialExtensions
         MetalMaterial? metalMaterial = null;
         foreach (var recipe in smithingRecipes)
         {
-            var ingredient = recipe.Output.ResolvedItemstack?.Collectible;
+            var ingredient = recipe.Output.ResolvedItemStack?.Collectible;
             if (ingredient == null) continue;
             var variantCode = ingredient.GetMetalVariant();
             metalMaterial = MetalMaterialLoader.GetMaterial(api, variantCode);

--- a/SmithingPlus/SmithingPlus.csproj
+++ b/SmithingPlus/SmithingPlus.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputPath>bin\$(Configuration)\Mods\mod</OutputPath>
   </PropertyGroup>
 

--- a/SmithingPlus/StoneSmithing/WorkItemRendererPatches.cs
+++ b/SmithingPlus/StoneSmithing/WorkItemRendererPatches.cs
@@ -28,8 +28,8 @@ public static class RegenMeshPostfixPatch
         ___recipeOutlineMeshRef?.Dispose();
         ___workItemMeshRef = null;
         ___recipeOutlineMeshRef = null;
-        var workItemMeshData = ItemWorkItem.GenMesh(___api, workitemStack, voxels, out var texId);
-        ___texId = texId;
+        var workItemMeshData = ItemWorkItem.GenMesh(___api, workitemStack, voxels); //, out var texId);
+        //___texId = texId;
         var recipeOutlineMeshData = GenOutlineMesh(___api, recipeToOutlineVoxels, voxels);
         for (var i = 0; i < workItemMeshData.xyz.Length; i += 3)
             workItemMeshData.xyz[i + 1] += yOffset;

--- a/SmithingPlus/ToolRecovery/ItemDamagedPatches.cs
+++ b/SmithingPlus/ToolRecovery/ItemDamagedPatches.cs
@@ -19,12 +19,12 @@ public class ItemDamagedPatches
     [HarmonyPatch(nameof(CollectibleObject.OnCreatedByCrafting))]
     [HarmonyPriority(-int.MaxValue)]
     public static void Postfix_OnCreatedByCrafting(
-        ItemSlot[] allInputslots,
+        ItemSlot[] allInputSlots,
         ItemSlot outputSlot,
         GridRecipe byRecipe)
     {
         if (outputSlot.Itemstack == null) return;
-        var brokenStack = allInputslots.FirstOrDefault(slot =>
+        var brokenStack = allInputSlots.FirstOrDefault(slot =>
             slot.Itemstack?.GetBrokenCount() > 0 &&
             slot.Itemstack?.Collectible.HasBehavior<CollectibleBehaviorRepairableToolHead>() == true
         )?.Itemstack;
@@ -34,9 +34,9 @@ public class ItemDamagedPatches
         if (brokenStack.Item?.IsRepairableTool() is not true) return;
         var repairedStack = brokenStack.GetRepairedToolStack();
         if (repairedStack == null) return;
-        repairedStack.ResolveBlockOrItem((allInputslots.FirstOrDefault()?.Inventory?.Api ?? Core.Api)
+        repairedStack.ResolveBlockOrItem((allInputSlots.FirstOrDefault()?.Inventory?.Api ?? Core.Api)
             .World);
-        if (repairedStack.Collectible.Code != byRecipe.Output.ResolvedItemstack.Collectible.Code) return;
+        if (repairedStack.Collectible.Code != byRecipe.Output.ResolvedItemStack.Collectible.Code) return;
         foreach (var attributeKey in Core.Config.GetToolRepairForgettableAttributes)
             repairedStack.Attributes?.RemoveAttribute(attributeKey);
         var repairSmith = brokenStack.GetRepairSmith();
@@ -57,18 +57,18 @@ public class ItemDamagedPatches
     private static void Prefix_DamageItem(
         IWorldAccessor world,
         Entity byEntity,
-        ItemSlot itemslot,
+        ItemSlot itemSlot,
         int amount)
     {
         if (world.Api.Side.IsClient())
             return;
-        var durability = itemslot?.Itemstack?.GetRemainingDurability();
+        var durability = itemSlot?.Itemstack?.GetRemainingDurability();
         if (!durability.HasValue || durability > amount) return;
-        if (itemslot.Itemstack?.Collectible.HasBehavior<CollectibleBehaviorRepairableTool>() != true) return;
-        Core.Logger.VerboseDebug("Broken tool in InventoryID: {0}, Entity: {1}", itemslot.Inventory?.InventoryID,
+        if (itemSlot.Itemstack?.Collectible.HasBehavior<CollectibleBehaviorRepairableTool>() != true) return;
+        Core.Logger.VerboseDebug("Broken tool in InventoryID: {0}, Entity: {1}", itemSlot.Inventory?.InventoryID,
             byEntity.GetName());
         var entityPlayer = byEntity as EntityPlayer;
-        var itemStack = itemslot.Itemstack;
+        var itemStack = itemSlot.Itemstack;
         var toolCode = itemStack?.Collectible.Code.ToString();
         var smithingRecipe = CacheHelper.GetOrAdd(Core.ToolToRecipeCache, toolCode,
             () => GetHeadSmithingRecipe(world.Api, itemStack));
@@ -91,8 +91,8 @@ public class ItemDamagedPatches
         Core.Logger.VerboseDebug("Found work item: {0}", workItem.Code);
         var wItemStack = new ItemStack(workItem);
         Core.Logger.VerboseDebug("Found smithing recipe: {0}",
-            smithingRecipe.Output.ResolvedItemstack.Collectible.Code);
-        var byteVoxels = ByteVoxelsFromRecipe(smithingRecipe, smithingRecipe.Output.ResolvedItemstack.StackSize);
+            smithingRecipe.Output.ResolvedItemStack.Collectible.Code);
+        var byteVoxels = ByteVoxelsFromRecipe(smithingRecipe, smithingRecipe.Output.ResolvedItemStack.StackSize);
         wItemStack.Attributes.SetBytes("voxels", BlockEntityAnvil.serializeVoxels(byteVoxels));
         wItemStack.Attributes.SetInt("selectedRecipeId", smithingRecipe.RecipeId);
         var cloneStack = itemStack?.Clone();
@@ -104,7 +104,7 @@ public class ItemDamagedPatches
         if (!gaveStack) world.SpawnItemEntity(wItemStack, byEntity.Pos.XYZ);
         Core.Logger.VerboseDebug(gaveStack ? "Gave work item {0} to player {1}" : "Dropped work item {0} to player {1}",
             wItemStack.Collectible.Code, entityPlayer?.Player.PlayerName);
-        itemslot.MarkDirty();
+        itemSlot.MarkDirty();
     }
 
     private static SmithingRecipe GetHeadSmithingRecipe(ICoreAPI api, ItemStack itemStack)
@@ -119,11 +119,11 @@ public class ItemDamagedPatches
         var toolRecipe = itemStack
             .GetGridRecipes(api)
             .FirstOrDefault(r =>
-                r.Output?.ResolvedItemstack?.StackSize == 1);
-        var toolHead = toolRecipe?.resolvedIngredients
+                r.Output?.ResolvedItemStack?.StackSize == 1);
+        var toolHead = toolRecipe?.ResolvedIngredients
             .FirstOrDefault(k =>
-                k?.ResolvedItemstack?.Collectible?.HasBehavior<CollectibleBehaviorRepairableToolHead>() ?? false)
-            ?.ResolvedItemstack;
+                k?.ResolvedItemStack?.Collectible?.HasBehavior<CollectibleBehaviorRepairableToolHead>() ?? false)
+            ?.ResolvedItemStack;
         if (toolHead == null)
         {
             toolHead = itemStack;

--- a/SmithingPlus/ToolRecovery/ToolHeadRepairPatches.cs
+++ b/SmithingPlus/ToolRecovery/ToolHeadRepairPatches.cs
@@ -42,10 +42,10 @@ public class ToolHeadRepairPatches
     public static void Prefix_DamageItem(
         IWorldAccessor world,
         Entity byEntity,
-        ItemSlot itemslot,
+        ItemSlot itemSlot,
         int amount = 1)
     {
-        var itemstack = itemslot?.Itemstack;
+        var itemstack = itemSlot?.Itemstack;
         if (!(itemstack?.Collectible.HasBehavior<CollectibleBehaviorRepairableTool>() ?? false)) return;
         var brokenCount = itemstack.GetBrokenCount();
         if (brokenCount < 0) return;

--- a/SmithingPlus/Util/CollectibleExtensions.cs
+++ b/SmithingPlus/Util/CollectibleExtensions.cs
@@ -76,7 +76,7 @@ public static class CollectibleExtensions
         var smithingRecipe = api.ModLoader
             .GetModSystem<RecipeRegistrySystem>()
             .SmithingRecipes
-            .FirstOrDefault(r => r.Output.ResolvedItemstack.Collectible.Code.Equals(collObj.Code));
+            .FirstOrDefault(r => r.Output.ResolvedItemStack.Collectible.Code.Equals(collObj.Code));
         return smithingRecipe;
     }
 
@@ -86,8 +86,8 @@ public static class CollectibleExtensions
         var smithingRecipes =
             from recipe in api.ModLoader.GetModSystem<RecipeRegistrySystem>().SmithingRecipes
             from ing in recipe.Ingredients
-            where ing.ResolvedItemstack is not null &&
-                  ing.ResolvedItemstack.Collectible.Code.Equals(collObj.Code)
+            where ing.ResolvedItemStack is not null &&
+                  ing.ResolvedItemStack.Collectible.Code.Equals(collObj.Code)
             select recipe;
         return smithingRecipes;
     }
@@ -96,10 +96,10 @@ public static class CollectibleExtensions
     {
         var gridRecipes =
             from recipe in api.World.GridRecipes
-            where recipe.resolvedIngredients != null
-            from ing in recipe.resolvedIngredients
-            where ing is { ResolvedItemstack.Collectible: not null } &&
-                  ing.ResolvedItemstack.Collectible.Code.Equals(collObj.Code)
+            where recipe.ResolvedIngredients != null
+            from ing in recipe.ResolvedIngredients
+            where ing is { ResolvedItemStack.Collectible: not null } &&
+                  ing.ResolvedItemStack.Collectible.Code.Equals(collObj.Code)
             select recipe;
         return gridRecipes;
     }

--- a/SmithingPlus/Util/ItemStackExtensions.cs
+++ b/SmithingPlus/Util/ItemStackExtensions.cs
@@ -128,7 +128,7 @@ public static class ItemStackExtensions
         var smithingRecipe = api.ModLoader
             .GetModSystem<RecipeRegistrySystem>()?
             .SmithingRecipes?
-            .FirstOrDefault(r => r?.Output?.ResolvedItemstack?.Satisfies(toolHead) == true);
+            .FirstOrDefault(r => r?.Output?.ResolvedItemStack?.Satisfies(toolHead) == true);
         return smithingRecipe;
     }
 
@@ -138,8 +138,8 @@ public static class ItemStackExtensions
             .GetModSystem<RecipeRegistrySystem>()?
             .SmithingRecipes?
             .FirstOrDefault(r =>
-                r?.Output?.ResolvedItemstack?.Satisfies(toolHead) == true
-                && r.Output.ResolvedItemstack.StackSize == withOutputStackSize);
+                r?.Output?.ResolvedItemStack?.Satisfies(toolHead) == true
+                && r.Output.ResolvedItemStack.StackSize == withOutputStackSize);
         return smithingRecipe;
     }
 
@@ -149,8 +149,8 @@ public static class ItemStackExtensions
         var smithingRecipe = api.ModLoader
                 .GetModSystem<RecipeRegistrySystem>()?
                 .SmithingRecipes?
-                .Where(r => r?.Output?.ResolvedItemstack?.Satisfies(toolHead) == true)
-                .OrderByDescending(r => r.Output.ResolvedItemstack.StackSize)
+                .Where(r => r?.Output?.ResolvedItemStack?.Satisfies(toolHead) == true)
+                .OrderByDescending(r => r.Output.ResolvedItemStack.StackSize)
                 .FirstOrDefault()
             ;
         return smithingRecipe;
@@ -162,8 +162,8 @@ public static class ItemStackExtensions
         var smithingRecipe = api.ModLoader
                 .GetModSystem<RecipeRegistrySystem>()?
                 .SmithingRecipes?
-                .Where(r => r?.Output?.ResolvedItemstack?.Satisfies(toolHead) == true)
-                .OrderByDescending(r => r.Voxels.VoxelCount() / r.Output.ResolvedItemstack.StackSize)
+                .Where(r => r?.Output?.ResolvedItemStack?.Satisfies(toolHead) == true)
+                .OrderByDescending(r => r.Voxels.VoxelCount() / r.Output.ResolvedItemStack.StackSize)
                 .FirstOrDefault()
             ;
         return smithingRecipe;
@@ -173,7 +173,7 @@ public static class ItemStackExtensions
     {
         var gridRecipes =
             from recipe in api.World.GridRecipes
-            where recipe.Output?.ResolvedItemstack?.Satisfies(itemStack) == true
+            where recipe.Output?.ResolvedItemStack?.Satisfies(itemStack) == true
             select recipe;
         return gridRecipes;
     }

--- a/SmithingPlus/modinfo.json
+++ b/SmithingPlus/modinfo.json
@@ -7,7 +7,7 @@
     "jayu"
   ],
   "description": "Metal tool repair, smithing tweaks and quality of life improvements.",
-  "version": "1.8.4",
+  "version": "1.8.4-rc 6",
   "dependencies": {
     "game": ""
   }


### PR DESCRIPTION
Really wanted to use this mod with the newest updates but saw it was failing to load, so I thought I would try and repair the changes made in the update.

After a few days testing it locally, I thought it could be useful to make a contribution so others might be able to use it.

Didn't alter anything major, just fixed compiler errors and patching issues as well as rolling versions to fit the latest game version.
(was 1.22.0-rc.6 at the time I did the work)

- Updated .net to 10.0
- Updated cake to 6.1.0
- Updated Newtonsoft.Json to 13.0.4
- Updated Directory.Build.props to reflect 1_22
- Changed OnCreatedByCrafting field allInputslots to allInputSlots
- Changed DamageItem field itemslot to itemSlot
- Changed CollectibleBehaviorRecycledBits IsToolStack toolIngredients field type GridRecipeIngredient[] to CraftingRecipeIngredient[]
- Changed BlockEntityForge.Contents to BlockEntityForge.WorkItemStack
- Changed Ingredient.ResolvedItemstack to Ingredient.ResolveItemStack
- Changed GridRecipe.resolvedIngredients to GridRecipe.ResolvedIngredients Fixed error in WorkItemRendererPatches inside unused skipped portion of RegenMesh_Postfix where GenMesh does not carry out texId as well as unused skipped assignemnt of __texId, commented for posterity