### PR TITLE
Split ClientConfig off of ServerConfig and synchronize upon joining Server

### DIFF
--- a/SmithingPlus/CastingTweaks/ToolMoldUnitsPatch.cs
+++ b/SmithingPlus/CastingTweaks/ToolMoldUnitsPatch.cs
@@ -37,22 +37,6 @@ public class ToolMoldUnitsPatch
         ___requiredUnits = requiredUnitsRounded;
     }
 
-    [HarmonyPostfix]
-    [HarmonyPatch(nameof(BlockEntityToolMold.ToTreeAttributes))]
-    public static void ToTreeAttributes_Postfix(BlockEntityToolMold __instance, int ___requiredUnits,
-        ITreeAttribute tree)
-    {
-        tree.SetInt("requiredUnits", ___requiredUnits);
-    }
-
-    [HarmonyPostfix]
-    [HarmonyPatch(nameof(BlockEntityToolMold.FromTreeAttributes))]
-    public static void FromTreeAttributes_Postfix(ITreeAttribute tree, ref int ___requiredUnits,
-        IWorldAccessor worldForResolve)
-    {
-        ___requiredUnits = tree.GetInt("requiredUnits");
-    }
-
     public static int GetPatchedRequiredUnits(ICoreAPI api, Block toolMold, ItemStack fromMetal)
     {
         var dropStacks = GetMoldedStacksStatic(api, toolMold, fromMetal);

--- a/SmithingPlus/ClientTweaks/AnvilRecipeSelectorPatch.cs
+++ b/SmithingPlus/ClientTweaks/AnvilRecipeSelectorPatch.cs
@@ -83,7 +83,7 @@ public static class AnvilRecipeSelectorPatch
     {
         _defaultSkillItemCache = ___skillItems;
         var cellCount = Math.Max(1, ___skillItems.Count);
-        var columns = Math.Min(cellCount, Core.Config?.AnvilRecipeSelectionColumns ?? 8);
+        var columns = Math.Min(cellCount, Core.CConfig?.AnvilRecipeSelectionColumns ?? 8);
         var rows = (int)Math.Ceiling(cellCount / (double)columns);
         var slotSize = GuiElementPassiveItemSlot.unscaledSlotSize + GuiElementItemSlotGridBase.unscaledSlotPadding;
         var fixedWidth = Math.Max(300.0, columns * slotSize);

--- a/SmithingPlus/Config/ClientConfig.cs
+++ b/SmithingPlus/Config/ClientConfig.cs
@@ -1,0 +1,13 @@
+namespace SmithingPlus.Config;
+
+public class ClientConfig
+{
+    public bool ShowRepairedCount { get; set; } = true;
+    public bool ShowBrokenCount { get; set; } = true;
+    public bool ShowRepairSmithName { get; set; } = false;
+    public bool AnvilShowRecipeVoxels { get; set; } = true;
+    public bool RememberHammerToolMode { get; set; } = true;
+    public bool ShowWorkableTemperature { get; set; } = true;
+    public bool HandbookExtraInfo { get; set; } = true;
+    public int AnvilRecipeSelectionColumns { get; set; } = 8;
+}

--- a/SmithingPlus/Config/ConfigLoader.cs
+++ b/SmithingPlus/Config/ConfigLoader.cs
@@ -7,8 +7,10 @@ namespace SmithingPlus.Config;
 [UsedImplicitly]
 public class ConfigLoader : ModSystem
 {
-    private const string ConfigName = "SmithingPlus.json";
+    private const string ServerConfigName = "SmithingPlus.json";
+    private const string ClientConfigName = "SmithingPlusClient.json";
     public static ServerConfig Config { get; private set; }
+    public static ClientConfig CConfig { get; private set; }
 
     public override double ExecuteOrder()
     {
@@ -19,14 +21,39 @@ public class ConfigLoader : ModSystem
     {
         try
         {
-            Config = api.LoadModConfig<ServerConfig>(ConfigName);
+            CConfig = api.LoadModConfig<ClientConfig>(ClientConfigName);
+            if (CConfig == null)
+            {
+                // Try to load settings from old mixed file
+                CConfig = api.LoadModConfig<ClientConfig>(ServerConfigName);
+                if (CConfig == null)
+                {
+                    CConfig = new ClientConfig();
+                    Mod.Logger.VerboseDebug("Client Config file not found, creating a new one...");
+                } else
+                {
+                    Mod.Logger.VerboseDebug("Client Config file not found, creating from old combined config");
+                }
+            }
+
+            api.StoreModConfig(CConfig, ClientConfigName);
+        }
+        catch (Exception e)
+        {
+            Mod.Logger.Error("Failed to load client config, you probably made a typo: {0}", e);
+            CConfig = new ClientConfig();
+        }
+
+        try
+        {
+            Config = api.LoadModConfig<ServerConfig>(ServerConfigName);
             if (Config == null)
             {
                 Config = new ServerConfig();
                 Mod.Logger.VerboseDebug("Config file not found, creating a new one...");
             }
 
-            api.StoreModConfig(Config, ConfigName);
+            api.StoreModConfig(Config, ServerConfigName);
         }
         catch (Exception e)
         {
@@ -55,6 +82,7 @@ public class ConfigLoader : ModSystem
     public override void Dispose()
     {
         Config = null;
+        CConfig = null;
         base.Dispose();
     }
 }

--- a/SmithingPlus/Config/ServerConfig.cs
+++ b/SmithingPlus/Config/ServerConfig.cs
@@ -25,9 +25,6 @@ public class ServerConfig
     public string WorkItemSelector { get; set; } = "@(.*):workitem-(.*)";
     public bool DontRepairBrokenToolHeads { get; set; } = false;
     public bool CanRepairForlornHopeEstoc { get; set; } = true;
-    public bool ShowRepairedCount { get; set; } = true;
-    public bool ShowBrokenCount { get; set; } = true;
-    public bool ShowRepairSmithName { get; set; } = false;
     public float HelveHammerSmithingQualityModifier { get; set; } = 1;
     public bool ArrowsDropBits { get; set; } = true;
     public string ArrowSelector { get; set; } = "@(.*):arrow-(.*)";
@@ -36,11 +33,6 @@ public class ServerConfig
     public bool DynamicMoldUnits { get; set; } = false;
     public bool HammerTweaks { get; set; } = true;
     public bool RotationRequiresTongs { get; set; } = false;
-    public bool AnvilShowRecipeVoxels { get; set; } = true;
-    public bool RememberHammerToolMode { get; set; } = true;
-    public bool ShowWorkableTemperature { get; set; } = true;
-    public bool HandbookExtraInfo { get; set; } = true;
-    public int AnvilRecipeSelectionColumns { get; set; } = 8;
 
     // public bool StoneSmithing { get; set; } = false;
     [JsonIgnore]

--- a/SmithingPlus/Core.cs
+++ b/SmithingPlus/Core.cs
@@ -26,7 +26,10 @@ public partial class Core : ModSystem
     public static ILogger Logger { get; private set; }
     public static ICoreAPI Api { get; private set; }
     public static Harmony HarmonyInstance { get; private set; }
-    public static ServerConfig Config => ConfigLoader.Config;
+    public static ServerConfig LocalConfig => ConfigLoader.Config;
+    public static ClientConfig CConfig => ConfigLoader.CConfig;
+    public static ServerConfig Config { get; private set; }
+    public static bool OnlyEnableClientside { get; private set; } = false;
 
     public override void StartPre(ICoreAPI api)
     {
@@ -55,6 +58,20 @@ public partial class Core : ModSystem
         api.RegisterItemClass($"{ModId}:ItemStoneHammer", typeof(ItemStoneHammer));
         api.RegisterBlockEntityClass($"{ModId}:StoneAnvil", typeof(BlockEntityStoneAnvil));
 
+        if (api.Side.IsServer())
+        {
+            Config = LocalConfig;
+            TreeAttributeSerializer<ServerConfig>.ToTreeAttributes(LocalConfig,api.World.Config.GetOrAddTreeAttribute("SmithingPlus"));
+        }
+        else
+        {
+            Config = new();
+            var tree = api.World.Config.GetTreeAttribute("SmithingPlus");
+            if(tree is not null)
+            {
+                TreeAttributeSerializer<ServerConfig>.FromTreeAttributes(Config,tree);    
+            }
+        }
         Patch();
     }
 
@@ -66,7 +83,7 @@ public partial class Core : ModSystem
 
     private static void AddEntityBehaviors(Entity entity)
     {
-        if (!Config.ArrowsDropBits || entity is not EntityProjectile projectile) return;
+        if (!LocalConfig.ArrowsDropBits || entity is not EntityProjectile projectile) return;
         if (!RecyclableArrowBehavior.IsRecyclableArrow(projectile)) return;
         Logger.VerboseDebug("Adding RecyclableArrowBehavior to {0}", entity.Code);
         entity.AddBehavior(new RecyclableArrowBehavior(entity));
@@ -75,16 +92,22 @@ public partial class Core : ModSystem
     public override void AssetsFinalize(ICoreAPI api)
     {
         base.AssetsFinalize(api);
-        foreach (var collObj in api.World.Collectibles.Where(c => c?.Code != null))
+        foreach (CollectibleObject collObj in api.World.Collectibles.Where(c => c?.Code != null))
         {
-            collObj.AddBehaviorIf<CollectibleBehaviorDisplayWorkableTemp>(
-                api.Side == EnumAppSide.Client &&
-                Config.ShowWorkableTemperature &&
-                collObj.GetCollectibleInterface<IAnvilWorkable>() is not null);
-            collObj.AddBehaviorIf<CollectibleBehaviorQuenchableInfo>(
-                api.Side == EnumAppSide.Client &&
-                Config.ShowWorkableTemperature &&
-                collObj.HasBehavior<CollectibleBehaviorQuenchable>());
+            if (api.Side.IsClient())
+            {
+                collObj.AddBehaviorIf<CollectibleBehaviorDisplayWorkableTemp>(
+                    CConfig.ShowWorkableTemperature &&
+                    collObj.GetCollectibleInterface<IAnvilWorkable>() is not null);
+                
+                collObj.AddBehaviorIf<CollectibleBehaviorQuenchableInfo>(
+                    CConfig.ShowWorkableTemperature &&
+                    collObj.HasBehavior<CollectibleBehaviorQuenchable>());
+                
+                continue; // These only apply to the client
+            }
+            // The rest apply to the server (which automatically adds them for the client as well)
+            
             collObj.AddBehaviorIf<CollectibleBehaviorScrapeCrucible>(Config.RecoverBitsOnSplit &&
                                                                      collObj is ItemChisel);
             collObj.AddBehaviorIf<CollectibleBehaviorSmeltedContainer>(Config.RecoverBitsOnSplit &&
@@ -113,7 +136,7 @@ public partial class Core : ModSystem
             // { "workableRecipe": true }
             // A better solution would be
             // to define the recipe with code instead of cloning an ingot recipe defined in the assets
-            if (api.Side.IsClient()) continue;
+
             var ingotCode = new AssetLocation("game:ingot-copper");
             var ingotRecipe = api.ModLoader.GetModSystem<RecipeRegistrySystem>().SmithingRecipes
                 .FirstOrDefault(r =>
@@ -154,23 +177,25 @@ public partial class Core : ModSystem
     private static void Patch()
     {
         if (HarmonyInstance != null) return;
+
         HarmonyInstance = new Harmony(ModId);
         Logger.VerboseDebug("Patching...");
         AlwaysPatchCategory.PatchIfEnabled(true);
         ToolRecoveryCategory.PatchIfEnabled(Config.EnableToolRecovery);
         SmithingRecipeAttributesPatch.PatchIfEnabled(
             Config.SmithWithBits || Config.BitsTopUp || Config.EnableToolRecovery, HarmonyInstance);
-        ClientTweaksCategories.RememberHammerToolMode.PatchIfEnabled(Config.RememberHammerToolMode);
-        ClientTweaksCategories.AnvilShowRecipeVoxels.PatchIfEnabled(Config.AnvilShowRecipeVoxels);
-        ClientTweaksCategories.ShowWorkablePatches.PatchIfEnabled(Config.ShowWorkableTemperature);
-        ClientTweaksCategories.HandbookExtraInfo.PatchIfEnabled(Config.HandbookExtraInfo);
+        
+        ClientTweaksCategories.RememberHammerToolMode.PatchIfEnabled(CConfig.RememberHammerToolMode);
+        ClientTweaksCategories.AnvilShowRecipeVoxels.PatchIfEnabled(CConfig.AnvilShowRecipeVoxels);
+        ClientTweaksCategories.ShowWorkablePatches.PatchIfEnabled(CConfig.ShowWorkableTemperature);
+        ClientTweaksCategories.HandbookExtraInfo.PatchIfEnabled(CConfig.HandbookExtraInfo);
+
         BitsRecoveryCategory.PatchIfEnabled(Config.RecoverBitsOnSplit);
         HelveHammerBitsRecoveryCategory.PatchIfEnabled(Config.HelveHammerBitsRecovery);
         CastingTweaksCategory.PatchIfEnabled(Config.MetalCastingTweaks);
         DynamicMoldsCategory.PatchIfEnabled(Config.DynamicMoldUnits);
         BitSmithingCategory.PatchIfEnabled(Config.SmithWithBits || Config.BitsTopUp);
         HammerTweaksCategory.PatchIfEnabled(Config.HammerTweaks);
-        //StoneSmithingCategory.PatchIfEnabled(true);
     }
 
     private static void Unpatch()

--- a/SmithingPlus/ToolRecovery/CollectibleBehaviorBrokenToolHead.cs
+++ b/SmithingPlus/ToolRecovery/CollectibleBehaviorBrokenToolHead.cs
@@ -48,7 +48,7 @@ public class CollectibleBehaviorBrokenToolHead(CollectibleObject collObj) : Coll
         if (world.Api is not ICoreClientAPI) return;
         var brokenCount = inSlot.Itemstack.GetBrokenCount();
         if (brokenCount <= 0) return;
-        if (Core.Config.ShowBrokenCount) dsc.AppendLine(Lang.Get($"{LangKey} {{0}} times", brokenCount));
+        if (Core.CConfig.ShowBrokenCount) dsc.AppendLine(Lang.Get($"{LangKey} {{0}} times", brokenCount));
         if (Core.Config.DontRepairBrokenToolHeads) dsc.AppendLine(Lang.Get($"{Core.ModId}:itemdesc-needschiseling"));
     }
 

--- a/SmithingPlus/ToolRecovery/CollectibleBehaviorRepairableTool.cs
+++ b/SmithingPlus/ToolRecovery/CollectibleBehaviorRepairableTool.cs
@@ -34,8 +34,8 @@ public class CollectibleBehaviorRepairableTool : CollectibleBehavior
             return;
         var brokenCount = inSlot.Itemstack.GetBrokenCount();
         if (brokenCount <= 0) return;
-        if (Core.Config.ShowRepairedCount) dsc.AppendLine(Lang.Get($"{LangKey} {{0}} times", brokenCount));
-        if (Core.Config.ShowRepairSmithName && inSlot.Itemstack.GetRepairSmith() is { } repairSmith)
+        if (Core.CConfig.ShowRepairedCount) dsc.AppendLine(Lang.Get($"{LangKey} {{0}} times", brokenCount));
+        if (Core.CConfig.ShowRepairSmithName && inSlot.Itemstack.GetRepairSmith() is { } repairSmith)
             dsc.AppendLine(Lang.Get("Last repaired by {0}", repairSmith));
     }
 }

--- a/SmithingPlus/Util/TreeAttributeSerialize.cs
+++ b/SmithingPlus/Util/TreeAttributeSerialize.cs
@@ -1,0 +1,48 @@
+
+
+using System.Reflection;
+using Vintagestory.API.Datastructures;
+
+namespace SmithingPlus.Util;
+
+public class TreeAttributeSerializer<T>
+{
+    public static void ToTreeAttributes(T obj, ITreeAttribute tree)
+    {
+        foreach (PropertyInfo fi in typeof(T).GetProperties())
+        {
+            var type = fi.PropertyType;
+            var name = fi.Name;
+            if (type == typeof(bool)) {
+                tree.SetBool(name,(bool)fi.GetValue(obj));
+            } else if (type==typeof(int)) {
+                tree.SetInt(name,(int)fi.GetValue(obj));
+            } else if (type==typeof(float)) {
+                tree.SetFloat(name,(float)fi.GetValue(obj));
+            } else if (type==typeof(string)) {
+                tree.SetString(name,(string)fi.GetValue(obj));
+            }
+        }
+    }
+
+    public static void FromTreeAttributes(T obj, ITreeAttribute tree)
+    {
+        foreach (PropertyInfo fi in typeof(T).GetProperties())
+        {
+            var type = fi.PropertyType;
+            var name = fi.Name;
+            if (type == typeof(bool)) {
+                bool? v = tree.TryGetBool(name);
+                if (v.HasValue) fi.SetValue(obj,v.Value);
+            } else if (type==typeof(int)) {
+                int? v = tree.TryGetInt(name);
+                if (v.HasValue) fi.SetValue(obj,v.Value);
+            } else if (type==typeof(float)) {
+                float? v = tree.TryGetFloat(name);
+                if (v.HasValue) fi.SetValue(obj,v.Value);
+            } else if (type==typeof(string)) {
+                if(tree.HasAttribute(name)) fi.SetValue(obj,tree.GetString(name));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Synchronize runtime ServerConfig with Server when joining.
fix some behaviours getting added twice.

Fixes #129 and probably other desync related bugs. Also fixes some of the double tooltip errors.

When no client config is found it tries to load the client values from the old shared SmithingPlus.json to create the new client config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate client-side configuration file for UI preferences and display settings.
  * Introduced new configuration options for client-specific behavior (repaired count visibility, repair smith name display, recipe visualization, and more).

* **Refactor**
  * Reorganized configuration system to separate server and client settings into distinct configuration files.
  * Migrated UI-related settings from server configuration to dedicated client configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->