### PR TITLE
Fix multi-minute freeze when generating anvil interaction help on large modlists

### DIFF
--- a/SmithingPlus/Common/Metal/MetalMaterialExtensions.cs
+++ b/SmithingPlus/Common/Metal/MetalMaterialExtensions.cs
@@ -15,8 +15,13 @@ public static class MetalMaterialExtensions
 
     public static MetalMaterial? GetOrCacheMetalMaterial(this CollectibleObject collObj, ICoreAPI api)
     {
-        var metalMaterial =
-            CacheHelper.GetOrAdd(Core.MetalMaterialCache, collObj.Code, () => collObj.GetMetalMaterial(api));
+        var cache = Core.MetalMaterialCache;
+        if (cache.TryGetValue(collObj.Code, out var cached)) return cached;
+        var metalMaterial = collObj.GetMetalMaterial(api);
+        // Negative results are only meaningful once the loader has resolved its materials;
+        // before that point every lookup returns null and must not poison the cache.
+        if (metalMaterial != null || api.GetModSystem<MetalMaterialLoader>()?.MaterialsResolved == true)
+            cache[collObj.Code] = metalMaterial;
         return metalMaterial;
     }
 
@@ -144,10 +149,10 @@ public static class MetalMaterialExtensions
     public static MetalMaterial? GetOrCacheMetalMaterial(this ItemStack itemStack, ICoreAPI api)
     {
         var collObj = itemStack.Collectible;
-        if (collObj is not IAnvilWorkable anvilWorkable) return collObj?.GetMetalMaterial(api);
+        if (collObj is not IAnvilWorkable anvilWorkable) return collObj?.GetOrCacheMetalMaterial(api);
         var ingotStack = anvilWorkable.GetBaseMaterial(itemStack);
         var metalMaterial = ingotStack.Collectible.GetOrCacheMetalMaterial(api);
-        return metalMaterial ?? collObj.GetMetalMaterial(api);
+        return metalMaterial ?? collObj.GetOrCacheMetalMaterial(api);
     }
 
     // Use when what matters is the processed result (e.g., iron bloom > iron, blister steel > steel)

--- a/SmithingPlus/Common/Metal/MetalMaterialLoader.cs
+++ b/SmithingPlus/Common/Metal/MetalMaterialLoader.cs
@@ -14,6 +14,7 @@ public class MetalMaterialLoader : ModSystem
 {
     private readonly Dictionary<AssetLocation, MetalMaterial> _metalMaterials = new();
     public Dictionary<AssetLocation, MetalMaterial> ResolvedMaterials { get; private set; } = new();
+    public bool MaterialsResolved { get; private set; }
 
     public override double ExecuteOrder()
     {
@@ -81,6 +82,7 @@ public class MetalMaterialLoader : ModSystem
         ResolvedMaterials = _metalMaterials
             .Where(kvp => kvp.Value.Resolved)
             .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+        MaterialsResolved = true;
         Core.Logger.Notification("[MetalMaterial] Done resolving metal materials.");
         Core.Logger.Notification(
             $"[MetalMaterial] Resolved {resolvedCount} out of {_metalMaterials.Count} metal materials.");

--- a/SmithingPlus/Util/CollectibleExtensions.cs
+++ b/SmithingPlus/Util/CollectibleExtensions.cs
@@ -73,33 +73,57 @@ public static class CollectibleExtensions
 
     public static SmithingRecipe? GetSmithingRecipe(this CollectibleObject collObj, ICoreAPI api)
     {
-        var smithingRecipe = api.ModLoader
-            .GetModSystem<RecipeRegistrySystem>()
-            .SmithingRecipes
-            .FirstOrDefault(r => r.Output.ResolvedItemstack.Collectible.Code.Equals(collObj.Code));
-        return smithingRecipe;
+        var byOutput = ObjectCacheUtil.GetOrCreate(api, $"{Core.ModId}:smithingRecipesByOutput", () =>
+        {
+            var dict = new Dictionary<AssetLocation, SmithingRecipe>();
+            foreach (var recipe in api.ModLoader.GetModSystem<RecipeRegistrySystem>().SmithingRecipes)
+            {
+                var code = recipe?.Output?.ResolvedItemstack?.Collectible?.Code;
+                if (code != null) dict.TryAdd(code, recipe!);
+            }
+
+            return dict;
+        });
+        return byOutput.TryGetValue(collObj.Code, out var smithingRecipe) ? smithingRecipe : null;
     }
 
     public static IEnumerable<SmithingRecipe> GetSmithingRecipesAsIngredient(this CollectibleObject collObj,
         ICoreAPI api)
     {
-        var smithingRecipes =
-            from recipe in api.ModLoader.GetModSystem<RecipeRegistrySystem>().SmithingRecipes
-            from ing in recipe.Ingredients
-            where ing.ResolvedItemStack?.Collectible?.Code?.Equals(collObj.Code) is true
-            select recipe;
-        return smithingRecipes;
+        var byIngredient = ObjectCacheUtil.GetOrCreate(api, $"{Core.ModId}:smithingRecipesByIngredient", () =>
+        {
+            var dict = new Dictionary<AssetLocation, List<SmithingRecipe>>();
+            foreach (var recipe in api.ModLoader.GetModSystem<RecipeRegistrySystem>().SmithingRecipes)
+            foreach (var ing in recipe.Ingredients)
+            {
+                var code = ing?.ResolvedItemStack?.Collectible?.Code;
+                if (code == null) continue;
+                if (!dict.TryGetValue(code, out var list)) dict[code] = list = [];
+                if (list.Count == 0 || list[^1] != recipe) list.Add(recipe);
+            }
+
+            return dict;
+        });
+        return byIngredient.TryGetValue(collObj.Code, out var recipes) ? recipes : [];
     }
 
     public static IEnumerable<GridRecipe> GetGridRecipesAsIngredient(this CollectibleObject collObj, ICoreAPI api)
     {
-        var gridRecipes =
-            from recipe in api.World.GridRecipes
-            from ing in recipe.RecipeIngredients
-            where ing is { ResolvedItemStack.Collectible: not null } &&
-                  ing.ResolvedItemStack?.Collectible?.Code?.Equals(collObj.Code) is true
-            select recipe;
-        return gridRecipes;
+        var byIngredient = ObjectCacheUtil.GetOrCreate(api, $"{Core.ModId}:gridRecipesByIngredient", () =>
+        {
+            var dict = new Dictionary<AssetLocation, List<GridRecipe>>();
+            foreach (var recipe in api.World.GridRecipes)
+            foreach (var ing in recipe.RecipeIngredients)
+            {
+                var code = ing?.ResolvedItemStack?.Collectible?.Code;
+                if (code == null) continue;
+                if (!dict.TryGetValue(code, out var list)) dict[code] = list = [];
+                if (list.Count == 0 || list[^1] != recipe) list.Add(recipe);
+            }
+
+            return dict;
+        });
+        return byIngredient.TryGetValue(collObj.Code, out var recipes) ? recipes : [];
     }
 
     public static CollectibleObject? CollectibleWithVariant(this CollectibleObject collObj, string type, string value)

--- a/SmithingPlus/Util/CollectibleExtensions.cs
+++ b/SmithingPlus/Util/CollectibleExtensions.cs
@@ -99,6 +99,7 @@ public static class CollectibleExtensions
                 var code = ing?.ResolvedItemStack?.Collectible?.Code;
                 if (code == null) continue;
                 if (!dict.TryGetValue(code, out var list)) dict[code] = list = [];
+                // Prevent duplicate entries when a recipe has the same ingredient multiple times
                 if (list.Count == 0 || list[^1] != recipe) list.Add(recipe);
             }
 


### PR DESCRIPTION
## Problem

The first time a player looks at an anvil after launch, `BlockAnvil.GetPlacedBlockInteractionHelp` builds its workable-item list by calling `GetRequiredAnvilTier(stack)` for every handbook stack of every `IAnvilWorkable` item. On a large modlist this froze the game for ~2 minutes per anvil tier (profiled hotspot: `GetGridRecipesAsIngredient`).

The cost came from three compounding issues in the metal material resolution that the tier check runs through:

1. **The `ItemStack` overload of `GetOrCacheMetalMaterial` bypassed the cache.** For any collectible whose *class* doesn''t implement `IAnvilWorkable` (i.e. every behavior-based workable such as the `CastToolHead` items matched by `ToolHeadSelector`), it called the private uncached `GetMetalMaterial` on every invocation.
2. **Failed resolutions were never cached.** `CacheHelper.GetOrAdd` skips storing `null`, so items with no resolvable metal material - exactly the ones that hit the expensive fallback, e.g. non-metal items matched by the broad default `ToolHeadSelector` regex (`head|blade|boss|barrel|stirrup|part`) - re-ran the full resolution on every single call.
3. **The fallback itself was a full scan**: a linear search of all smithing recipes plus an enumeration of all grid recipes x all ingredients, with LINQ allocations, per call.

## Fix

- `GetSmithingRecipe`, `GetSmithingRecipesAsIngredient`, and `GetGridRecipesAsIngredient` now build a one-time reverse index (recipes keyed by output/ingredient collectible code) lazily via `ObjectCacheUtil`, turning each lookup into a dictionary hit.
- `GetOrCacheMetalMaterial(CollectibleObject)` now caches negative results too. A new `MaterialsResolved` flag on `MetalMaterialLoader` guards this so lookups that happen before `AssetsFinalize` can''t poison the cache with premature nulls.
- The `ItemStack` overload routes both of its fallback paths through the cached collectible-level method.

`CacheHelper.GetOrAdd` is left unchanged since other callers rely on its retry-on-null behavior. The indexed lookups return the same recipes the old LINQ queries did (minus exact duplicates of the same recipe, which no caller depended on).

## Results

Tested on a large modlist: the first anvil tooltip went from a ~2 minute freeze to a ~200 ms stutter. Behavior is otherwise unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed metal material caching to prevent storing null values during initial resource loading, which could cause incorrect results later.

* **Improvements**
  * Optimized smithing and grid recipe lookups by using precomputed cached indices instead of repeated queries.
  * Enhanced metal material resolution tracking to ensure caching only occurs after all materials are properly resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->